### PR TITLE
Upload at cloud search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile postgresClient, jdbi, jackson_mapper
+    compile postgresClient, jdbi, aws_cloudsearch
     testCompile junit, mockito
 }
 

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -2,7 +2,7 @@ ext {
 
     postgresClient = 'org.postgresql:postgresql:9.4-1200-jdbc41'
     jdbi = 'org.jdbi:jdbi:2.59'
-    jackson_mapper = 'org.codehaus.jackson:jackson-mapper-asl:1.9.13'
+    aws_cloudsearch = 'com.amazonaws:aws-java-sdk-cloudsearch:1.10.22'
 
     //test dependency
     junit = 'junit:junit:4.12'

--- a/src/main/java/uk/gov/indexer/AWSCloudSearch.java
+++ b/src/main/java/uk/gov/indexer/AWSCloudSearch.java
@@ -1,0 +1,57 @@
+package uk.gov.indexer;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.cloudsearchdomain.AmazonCloudSearchDomain;
+import com.amazonaws.services.cloudsearchdomain.AmazonCloudSearchDomainClient;
+import com.amazonaws.services.cloudsearchdomain.model.ContentType;
+import com.amazonaws.services.cloudsearchdomain.model.UploadDocumentsRequest;
+import com.amazonaws.services.cloudsearchdomain.model.UploadDocumentsResult;
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Lists;
+import uk.gov.indexer.dao.Entry;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class AWSCloudSearch {
+
+    private final AmazonCloudSearchDomain cloudSearchDomain;
+    private final String registerName;
+
+    public AWSCloudSearch(String registerName, String searchDomainEndPoint) {
+        this.registerName = registerName;
+        this.cloudSearchDomain = new AmazonCloudSearchDomainClient(new DefaultAWSCredentialsProviderChain());
+        this.cloudSearchDomain.setRegion(Region.getRegion(Regions.EU_WEST_1));
+        this.cloudSearchDomain.setEndpoint(searchDomainEndPoint);
+    }
+
+    public void upload(List<Entry> entries) {
+        byte[] bytes = Jackson.toJsonString(Lists.transform(entries, this::document)).getBytes(StandardCharsets.UTF_8);
+        System.out.println("new String(bytes) = " + new String(bytes));
+        UploadDocumentsRequest uploadDocumentsRequest = new UploadDocumentsRequest();
+        uploadDocumentsRequest.setContentType(ContentType.Applicationjson);
+        uploadDocumentsRequest.setContentLength((long) bytes.length);
+        uploadDocumentsRequest.setDocuments(new ByteArrayInputStream(bytes));
+        UploadDocumentsResult uploadDocumentsResult = cloudSearchDomain.uploadDocuments(uploadDocumentsRequest);
+
+        //TODO: handle result
+        System.out.println("uploadDocumentsResult = " + uploadDocumentsResult);
+    }
+
+
+    private ObjectNode document(Entry e) {
+        JsonNode jsonNode = Jackson.jsonNodeOf(new String(e.contents, StandardCharsets.UTF_8));
+        ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+        objectNode.put("type", "add");
+        objectNode.put("id", jsonNode.get("entry").get(registerName).textValue());
+        //TODO: this should be document with hash
+        objectNode.set("fields", jsonNode.get("entry"));
+        return objectNode;
+    }
+}

--- a/src/main/java/uk/gov/indexer/AWSCloudSearch.java
+++ b/src/main/java/uk/gov/indexer/AWSCloudSearch.java
@@ -33,17 +33,16 @@ public class AWSCloudSearch {
 
     public void upload(List<Entry> entries) {
         byte[] bytes = Jackson.toJsonString(Lists.transform(entries, this::document)).getBytes(StandardCharsets.UTF_8);
-        System.out.println("new String(bytes) = " + new String(bytes));
         UploadDocumentsRequest uploadDocumentsRequest = new UploadDocumentsRequest();
         uploadDocumentsRequest.setContentType(ContentType.Applicationjson);
         uploadDocumentsRequest.setContentLength((long) bytes.length);
         uploadDocumentsRequest.setDocuments(new ByteArrayInputStream(bytes));
         UploadDocumentsResult uploadDocumentsResult = cloudSearchDomain.uploadDocuments(uploadDocumentsRequest);
 
-        //TODO: handle result
-        System.out.println("uploadDocumentsResult = " + uploadDocumentsResult);
+        if (!"success".equalsIgnoreCase(uploadDocumentsResult.getStatus())) {
+            throw new RuntimeException("Address upload request failed: " + uploadDocumentsResult.toString());
+        }
     }
-
 
     private ObjectNode document(Entry e) {
         JsonNode jsonNode = Jackson.jsonNodeOf(new String(e.contents, StandardCharsets.UTF_8));

--- a/src/main/java/uk/gov/indexer/Application.java
+++ b/src/main/java/uk/gov/indexer/Application.java
@@ -31,7 +31,7 @@ public class Application {
                 DestinationDBUpdateDAO destinationQueryDAO = createDestinationDAO(register, configuration);
                 SourceDBQueryDAO sourceQueryDAO = createSourceDAO(register, configuration);
 
-                executorService.scheduleAtFixedRate(new IndexerTask(register, sourceQueryDAO, destinationQueryDAO), 0, 10, TimeUnit.SECONDS);
+                executorService.scheduleAtFixedRate(new IndexerTask(register, sourceQueryDAO, destinationQueryDAO, configuration.cloudSearchEndPoint(register)), 0, 10, TimeUnit.SECONDS);
             } catch (Throwable e) {
                 e.printStackTrace();
                 ConsoleLogger.log("Error occurred while setting indexer for register: " + register + ". Error is -> " + e.getMessage());

--- a/src/main/java/uk/gov/indexer/Configuration.java
+++ b/src/main/java/uk/gov/indexer/Configuration.java
@@ -4,26 +4,32 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 class Configuration {
     private final Set<String> registers;
     private final Properties properties;
+    private final Map<String, String> cloudSearchEndPoints;
 
     public Configuration(String[] args) {
         try {
             this.properties = new Properties();
             properties.load(configurationPropertiesStream(createConfigurationMap(args).get("config.file")));
             this.registers = extractConfiguredRegisters();
+            this.cloudSearchEndPoints = createCloudSearchEndPoints();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
+    private Map<String, String> createCloudSearchEndPoints() {
+        return properties.keySet()
+                .stream()
+                .map(Object::toString)
+                .filter(key -> key.endsWith(".cloudsearch.endpoint"))
+                .collect(Collectors.toMap(key -> key.split("\\.")[0], properties::getProperty));
+    }
 
     private InputStream configurationPropertiesStream(String fileName) throws IOException {
         if (fileName == null || fileName.trim().equals("")) {
@@ -62,4 +68,7 @@ class Configuration {
         return properties.getProperty(key);
     }
 
+    public Optional<String> cloudSearchEndPoint(String register) {
+        return Optional.ofNullable(cloudSearchEndPoints.get(register));
+    }
 }

--- a/src/main/java/uk/gov/indexer/IndexerTask.java
+++ b/src/main/java/uk/gov/indexer/IndexerTask.java
@@ -5,16 +5,19 @@ import uk.gov.indexer.dao.Entry;
 import uk.gov.indexer.dao.SourceDBQueryDAO;
 
 import java.util.List;
+import java.util.Optional;
 
 public class IndexerTask implements Runnable {
     private final String register;
     private final SourceDBQueryDAO sourceDBQueryDAO;
     private final DestinationDBUpdateDAO destinationDBUpdateDAO;
+    private final Optional<AWSCloudSearch> cloudSearch;
 
-    public IndexerTask(String register, SourceDBQueryDAO sourceDBQueryDAO, DestinationDBUpdateDAO destinationDBUpdateDAO) {
+    public IndexerTask(String register, SourceDBQueryDAO sourceDBQueryDAO, DestinationDBUpdateDAO destinationDBUpdateDAO, Optional<String> searchDomainEndPoint) {
         this.register = register;
         this.sourceDBQueryDAO = sourceDBQueryDAO;
         this.destinationDBUpdateDAO = destinationDBUpdateDAO;
+        this.cloudSearch = searchDomainEndPoint.map(ep -> new AWSCloudSearch(register, ep));
     }
 
     @Override
@@ -32,7 +35,12 @@ public class IndexerTask implements Runnable {
         List<Entry> entries;
         while (!(entries = fetchNewEntries()).isEmpty()) {
             destinationDBUpdateDAO.writeEntriesInBatch(register, entries);
+            uploadEntriesTocloudSearch(entries);
         }
+    }
+
+    private void uploadEntriesTocloudSearch(final List<Entry> entries) {
+        cloudSearch.ifPresent(cs -> cs.upload(entries));
     }
 
     private List<Entry> fetchNewEntries() {

--- a/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
@@ -2,7 +2,6 @@ package uk.gov.indexer.dao;
 
 import org.skife.jdbi.v2.sqlobject.*;
 
-import java.util.Iterator;
 import java.util.List;
 
 interface CurrentKeysUpdateDAO extends DBConnectionDAO {
@@ -18,6 +17,6 @@ interface CurrentKeysUpdateDAO extends DBConnectionDAO {
     List<String> getExistingKeys(@Bind("keys") String keys);
 
     @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(SERIAL_NUMBER, KEY) values(:serial_number, :primaryKey)")
-    void insertEntries(@BindBean Iterator<OrderedIndexEntry> entries);
+    void insertEntries(@BindBean Iterable<OrderedIndexEntry> entries);
 }
 

--- a/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
@@ -1,7 +1,6 @@
 package uk.gov.indexer.dao;
 
 import com.google.common.collect.Lists;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.TransactionIsolationLevel;
 import org.skife.jdbi.v2.sqlobject.Transaction;
@@ -12,7 +11,6 @@ import java.util.stream.Collectors;
 
 
 public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionDAO {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
     private final TotalRegisterEntriesUpdateDAO totalRegisterEntriesUpdateDAO;
     private final CurrentKeysUpdateDAO currentKeysUpdateDAO;
     private final IndexedEntriesUpdateDAO indexedEntriesUpdateDAO;

--- a/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
@@ -39,7 +39,7 @@ public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionD
     public void writeEntriesInBatch(String registerName, List<Entry> entries) {
 
         List<OrderedIndexEntry> orderedIndexEntry = entries.stream().map((entry) -> entry.dbEntry(registerName)).collect(Collectors.toList());
-        indexedEntriesUpdateDAO.writeBatch(orderedIndexEntry.iterator());
+        indexedEntriesUpdateDAO.writeBatch(orderedIndexEntry);
         totalRegisterEntriesUpdateDAO.increaseTotalEntriesInRegisterCount(orderedIndexEntry.size());
         upsertInCurrentKeysTable(orderedIndexEntry);
     }
@@ -56,6 +56,6 @@ public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionD
         for (OrderedIndexEntry updateEntry : updateEntries) {
             currentKeysUpdateDAO.updateSerialNumber(updateEntry.serial_number, updateEntry.primaryKey);
         }
-        currentKeysUpdateDAO.insertEntries(newEntries.iterator());
+        currentKeysUpdateDAO.insertEntries(newEntries);
     }
 }

--- a/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
@@ -5,8 +5,6 @@ import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 
-import java.util.Iterator;
-
 interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
     String INDEXED_ENTRIES_TABLE = "ORDERED_ENTRY_INDEX";
 
@@ -17,5 +15,5 @@ interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
     int lastReadSerialNumber();
 
     @SqlBatch("INSERT INTO " + INDEXED_ENTRIES_TABLE + "(SERIAL_NUMBER, ENTRY) VALUES(:serial_number, :content)")
-    void writeBatch(@BindBean Iterator<OrderedIndexEntry> orderedIndexEntry);
+    void writeBatch(@BindBean Iterable<OrderedIndexEntry> orderedIndexEntry);
 }

--- a/src/main/java/uk/gov/indexer/dao/OrderedIndexEntry.java
+++ b/src/main/java/uk/gov/indexer/dao/OrderedIndexEntry.java
@@ -1,14 +1,12 @@
 package uk.gov.indexer.dao;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.postgresql.util.PGobject;
 
 import java.sql.SQLException;
 
 public class OrderedIndexEntry {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     public final int serial_number;
     public final PGobject content;
     public final String primaryKey;
@@ -20,16 +18,8 @@ public class OrderedIndexEntry {
     }
 
     private String getKey(String registerName, String entry) {
-        JsonNode jsonNode = getJsonNode(entry);
-        return jsonNode.get("entry").get(registerName).getTextValue();
-    }
-
-    private JsonNode getJsonNode(String entry) {
-        try {
-            return objectMapper.readTree(entry);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        JsonNode jsonNode = Jackson.jsonNodeOf(entry);
+        return jsonNode.get("entry").get(registerName).textValue();
     }
 
     private PGobject pgObject(String entry) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,4 @@
 school.source.postgres.db.connectionString=jdbc:postgresql://localhost:5432/postgres?user=postgres
 school.destination.postgres.db.connectionString=jdbc:postgresql://localhost:5432/postgres?user=postgres
+school.cloudsearch.endpoint=ThisIsExamplePropertyToConfigureACloudSearchDomainEndPointForTheRegister
 
-school.cloudsearch.endpoint=schoolCloudSearchDomainEndPoint
-
-#address.cloudsearch.endpoint=search-address-ijvg333jgmctttdl7rzjush2u4.eu-west-1.cloudsearch.amazonaws.com

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,6 @@
 school.source.postgres.db.connectionString=jdbc:postgresql://localhost:5432/postgres?user=postgres
 school.destination.postgres.db.connectionString=jdbc:postgresql://localhost:5432/postgres?user=postgres
+
+school.cloudsearch.endpoint=schoolCloudSearchDomainEndPoint
+
+#address.cloudsearch.endpoint=search-address-ijvg333jgmctttdl7rzjush2u4.eu-west-1.cloudsearch.amazonaws.com


### PR DESCRIPTION
Changes in PR enables the indexer to feed data in cloudsearch domain if configured for a register.

Currently there can be a case that when the data is indexed in read api database but failed to load in cloudsearch domain. Both tasks should complete in the transaction. More work will be done to resolve the potential issue.
