### PR TITLE
Inlined AWS_DEFAULT_REGION in aws commands

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -3,8 +3,7 @@
 set -eu
 
 INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
-export AWS_DEFAULT_REGION=eu-west-1
-ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --query 'Tags[0].Value' --output text)
+ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --region eu-west-1 --query 'Tags[0].Value' --output text)
 CONFIG_BUCKET=openregister.${ENV}.config
 
 aws s3 cp s3://${CONFIG_BUCKET}/indexer/indexer.properties /srv/indexer --region eu-west-1


### PR DESCRIPTION
Specifying AWS_DEFAULT_REGION environment variable was not working so inlined with aws command. I think it does not work when using IAM role for AWS resource access.
