### PR TITLE
Using @BindIn for in-query instead of creating comma separated string.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile postgresClient, jdbi, aws_cloudsearch
+    compile postgresClient, jdbi, aws_cloudsearch, stringTemplate
     testCompile junit, mockito
 }
 

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,7 +1,8 @@
 ext {
 
     postgresClient = 'org.postgresql:postgresql:9.4-1200-jdbc41'
-    jdbi = 'org.jdbi:jdbi:2.59'
+    jdbi = 'org.jdbi:jdbi:2.63.1'
+    stringTemplate= 'org.antlr:stringtemplate:3.2.1'
     aws_cloudsearch = 'com.amazonaws:aws-java-sdk-cloudsearch:1.10.22'
 
     //test dependency

--- a/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
@@ -1,9 +1,12 @@
 package uk.gov.indexer.dao;
 
 import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import org.skife.jdbi.v2.unstable.BindIn;
 
 import java.util.List;
 
+@UseStringTemplate3StatementLocator
 interface CurrentKeysUpdateDAO extends DBConnectionDAO {
     String CURRENT_KEYS_TABLE = "CURRENT_KEYS";
 
@@ -13,8 +16,8 @@ interface CurrentKeysUpdateDAO extends DBConnectionDAO {
     @SqlUpdate("UPDATE " + CURRENT_KEYS_TABLE + " SET SERIAL_NUMBER=:serial_number WHERE KEY=:key")
     int updateSerialNumber(@Bind("serial_number") int serial_number, @Bind("key") String key);
 
-    @SqlQuery("SELECT KEY FROM " + CURRENT_KEYS_TABLE + " WHERE KEY IN (:keys)")
-    List<String> getExistingKeys(@Bind("keys") String commaSeparatedKeys);
+    @SqlQuery("SELECT KEY FROM " + CURRENT_KEYS_TABLE + " WHERE KEY IN (<keys>)")
+    List<String> getExistingKeys(@BindIn("keys") Iterable<String> keys);
 
     @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(SERIAL_NUMBER, KEY) values(:serial_number, :key)")
     void insertEntries(@BindBean Iterable<CurrentKey> keys);

--- a/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
@@ -51,7 +51,7 @@ public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionD
 
         List<String> allKeys = Lists.transform(orderedEntryIndexes, e -> getKey(registerName, e.getEntry()));
 
-        List<String> existingKeys = currentKeysUpdateDAO.getExistingKeys(String.join(",", allKeys));
+        List<String> existingKeys = currentKeysUpdateDAO.getExistingKeys(allKeys);
 
         Iterable<OrderedEntryIndex> newEntries = Iterables.filter(orderedEntryIndexes, e -> !existingKeys.contains(getKey(registerName, e.getEntry())));
 


### PR DESCRIPTION
ResolvedBug: We were passing comma separated string of primary keys for in-query to filter existing keys from current table which was ending up a single value instead of multiple values in in-query. Using string template now and using jdbi @BindIn annotation to solve the bug which is much better solution.
