### PR TITLE
Insert/update in current_keys table one by one

### DIFF
--- a/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
@@ -1,10 +1,12 @@
 package uk.gov.indexer.dao;
 
-import org.skife.jdbi.v2.sqlobject.*;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.unstable.BindIn;
 
-import java.util.List;
+import java.util.Set;
 
 @UseStringTemplate3StatementLocator
 interface CurrentKeysUpdateDAO extends DBConnectionDAO {
@@ -17,9 +19,9 @@ interface CurrentKeysUpdateDAO extends DBConnectionDAO {
     int updateSerialNumber(@Bind("serial_number") int serial_number, @Bind("key") String key);
 
     @SqlQuery("SELECT KEY FROM " + CURRENT_KEYS_TABLE + " WHERE KEY IN (<keys>)")
-    List<String> getExistingKeys(@BindIn("keys") Iterable<String> keys);
+    Set<String> getExistingKeys(@BindIn("keys") Iterable<String> keys);
 
-    @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(SERIAL_NUMBER, KEY) values(:serial_number, :key)")
-    void insertEntries(@BindBean Iterable<CurrentKey> keys);
+    @SqlUpdate("INSERT INTO " + CURRENT_KEYS_TABLE + "(SERIAL_NUMBER, KEY) VALUES(:serial_number, :key)")
+    void insertNewKey(@Bind("serial_number") int serial_number, @Bind("key") String key);
 }
 


### PR DESCRIPTION
Insert/update in current_keys table one by one instead of batch to resolve the possible bug.

  In a batch if there are two entries in which one supersedes other the insert operation will fail because of unique index. in this case the serial_number must be updated in current_keys table instead of adding as a new entry. Now check every entry one by one, if exists update else insert as a new entry.
