### PR TITLE
Renamed the deployment group to match oit with the preview environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ deploy:
   key: indexer-$TRAVIS_BRANCH-$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT.zip
   bundle_type: zip
   application: indexer-app
-  deployment_group: preview-indexer
+  deployment_group: preview
   region: eu-west-1
   on: *2


### PR DESCRIPTION
   having a deployment group same as environment name helps automating of register creation
