### PR TITLE
create GIN index on jsonb column

### DIFF
--- a/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
@@ -27,6 +27,9 @@ public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionD
         indexedEntriesUpdateDAO = handle.attach(IndexedEntriesUpdateDAO.class);
 
         indexedEntriesUpdateDAO.ensureIndexedEntriesTableExists();
+        if (!indexedEntriesUpdateDAO.indexedEntriesIndexExists()) {
+            indexedEntriesUpdateDAO.createIndexedEntriesIndex();
+        }
 
         currentKeysUpdateDAO.ensureCurrentKeysTableExists();
 

--- a/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
@@ -7,9 +7,16 @@ import java.util.List;
 
 public interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
     String INDEXED_ENTRIES_TABLE = "ORDERED_ENTRY_INDEX";
+    String INDEXED_ENTRIES_INDEX = INDEXED_ENTRIES_TABLE + "_GIN";
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS " + INDEXED_ENTRIES_TABLE + " (SERIAL_NUMBER INTEGER PRIMARY KEY, ENTRY JSONB)")
     void ensureIndexedEntriesTableExists();
+
+    @SqlUpdate("CREATE INDEX " + INDEXED_ENTRIES_INDEX + " ON " + INDEXED_ENTRIES_TABLE + " USING gin(ENTRY jsonb_path_ops)")
+    void createIndexedEntriesIndex();
+
+    @SqlQuery("SELECT 1 FROM pg_indexes WHERE indexname='" + INDEXED_ENTRIES_INDEX + "'")
+    boolean indexedEntriesIndexExists();
 
     @SqlQuery("SELECT MAX(SERIAL_NUMBER) FROM " + INDEXED_ENTRIES_TABLE)
     int lastReadSerialNumber();


### PR DESCRIPTION
Some of our queries are really slow because they are doing a full table
scan.  Because we're using jsonb, we can create a [gin index](http://www.postgresql.org/docs/9.4/static/datatype-json.html) to make
these queries much more efficient.

There's an argument that the only things we care about in the data are
the primary key and the hash, so maybe we should instead pull those out
into separate columns and index that?  We don't need the fully
arbitrary querying capability of a general json index. :shrug:
