### PR TITLE
Extract Indexer class and start in parallel

### DIFF
--- a/src/main/java/uk/gov/indexer/Application.java
+++ b/src/main/java/uk/gov/indexer/Application.java
@@ -1,87 +1,32 @@
 package uk.gov.indexer;
 
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import uk.gov.indexer.dao.DBConnectionDAO;
-import uk.gov.indexer.dao.DestinationDBUpdateDAO;
-import uk.gov.indexer.dao.IndexedEntriesUpdateDAO;
-import uk.gov.indexer.dao.SourceDBQueryDAO;
-
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 public class Application {
-    private final static Runtime runtime = Runtime.getRuntime();
-    private final static List<DBConnectionDAO> databaseObjectRegistry = new ArrayList<>();
-
-    public static void main(String[] args) throws IOException, SQLException, InterruptedException {
+    public static void main(String[] args) throws InterruptedException {
         Configuration configuration = new Configuration(args);
         Set<String> registers = configuration.getRegisters();
 
         ScheduledExecutorService executorService = Executors.newScheduledThreadPool((int) registers.stream().filter(r -> configuration.cloudSearchEndPoint(r).isPresent()).count() + registers.size());
 
-        addShutdownHook(executorService);
+        Stream<Indexer> indexerStream = registers.stream().map(r -> new Indexer(configuration, r));
 
-        for (String register : registers) {
-            try {
-                ConsoleLogger.log("setting up register " + register);
-                DBI dbi = new DBI(configuration.getProperty(register + ".destination.postgres.db.connectionString"));
+        addShutdownHook(executorService, indexerStream);
 
-                DestinationDBUpdateDAO destinationDBUpdateDAO = createDestinationDBUpdateDAO(dbi);
-
-                executorService.scheduleAtFixedRate(
-                        new IndexerTask(register, createSourceDAO(register, configuration), destinationDBUpdateDAO),
-                        0,
-                        10,
-                        TimeUnit.SECONDS
-                );
-
-                configuration.cloudSearchEndPoint(register).ifPresent(
-                        endPoint -> executorService.scheduleAtFixedRate(
-                                new CloudSearchDataUploadTask(register, endPoint, configuration.cloudSearchWaterMarkEndPoint(register).get(), dbi.onDemand(IndexedEntriesUpdateDAO.class)),
-                                0,
-                                5,
-                                TimeUnit.MINUTES
-                        )
-                );
-
-
-            } catch (Throwable e) {
-                e.printStackTrace();
-                ConsoleLogger.log("Error occurred while setting indexer for register: " + register + ". Error is -> " + e.getMessage());
-            }
-        }
+        indexerStream.parallel().forEach(indexer -> indexer.start(executorService));
 
         Thread.currentThread().join();
     }
 
-    private static SourceDBQueryDAO createSourceDAO(String register, Configuration configuration) {
-        DBI dbi = new DBI(configuration.getProperty(register + ".source.postgres.db.connectionString"));
-        SourceDBQueryDAO sourceDBQueryDAO = dbi.onDemand(SourceDBQueryDAO.class);
-        databaseObjectRegistry.add(sourceDBQueryDAO);
-        return sourceDBQueryDAO;
-    }
-
-    private static DestinationDBUpdateDAO createDestinationDBUpdateDAO(DBI dbi) {
-        Handle handle = dbi.open();
-        DestinationDBUpdateDAO destinationDBUpdateDAO = handle.attach(DestinationDBUpdateDAO.class);
-        databaseObjectRegistry.add(destinationDBUpdateDAO);
-        return destinationDBUpdateDAO;
-    }
-
-
-    private static void addShutdownHook(final ScheduledExecutorService executorService) {
-        runtime.addShutdownHook(new Thread() {
+    private static void addShutdownHook(final ScheduledExecutorService executorService, Stream<Indexer> indexerStream) {
+        Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
                 executorService.shutdown();
-                databaseObjectRegistry.forEach(DBConnectionDAO::close);
+                indexerStream.forEach(Indexer::stop);
                 ConsoleLogger.log("Shutdown completed...");
             }
         });

--- a/src/main/java/uk/gov/indexer/Indexer.java
+++ b/src/main/java/uk/gov/indexer/Indexer.java
@@ -1,0 +1,63 @@
+package uk.gov.indexer;
+
+import org.skife.jdbi.v2.DBI;
+import uk.gov.indexer.dao.DestinationDBUpdateDAO;
+import uk.gov.indexer.dao.IndexedEntriesUpdateDAO;
+import uk.gov.indexer.dao.SourceDBQueryDAO;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class Indexer {
+    private final Configuration configuration;
+    private final String register;
+    private DestinationDBUpdateDAO destinationDBUpdateDAO;
+    private SourceDBQueryDAO sourceDBQueryDAO;
+
+    public Indexer(Configuration configuration, String register) {
+        this.configuration = configuration;
+        this.register = register;
+    }
+
+    public synchronized void start(ScheduledExecutorService executorService) {
+        try {
+            ConsoleLogger.log("setting up register " + register);
+
+            DBI destDbi = new DBI(configuration.getProperty(register + ".destination.postgres.db.connectionString"));
+            DBI sourceDbi = new DBI(configuration.getProperty(register + ".source.postgres.db.connectionString"));
+
+            destinationDBUpdateDAO = destDbi.open().attach(DestinationDBUpdateDAO.class);
+
+            sourceDBQueryDAO = sourceDbi.onDemand(SourceDBQueryDAO.class);
+            executorService.scheduleAtFixedRate(
+                    new IndexerTask(register, sourceDBQueryDAO, destinationDBUpdateDAO),
+                    0,
+                    10,
+                    TimeUnit.SECONDS
+            );
+
+            configuration.cloudSearchEndPoint(register).ifPresent(
+                    endPoint -> executorService.scheduleAtFixedRate(
+                            new CloudSearchDataUploadTask(register, endPoint, configuration.cloudSearchWaterMarkEndPoint(register).get(), destDbi.onDemand(IndexedEntriesUpdateDAO.class)),
+                            0,
+                            5,
+                            TimeUnit.MINUTES
+                    )
+            );
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+            ConsoleLogger.log("Error occurred while setting indexer for register: " + register + ". Error is -> " + e.getMessage());
+        }
+
+    }
+
+    public synchronized void stop() {
+        if (destinationDBUpdateDAO != null) {
+            destinationDBUpdateDAO.close();
+        }
+        if (sourceDBQueryDAO != null) {
+            sourceDBQueryDAO.close();
+        }
+    }
+}


### PR DESCRIPTION
Because the DestinationDBUpdateDAO instance tries to create an index in
its constructor, and we create these objects in series in the main()
method, we can block the indexing of all registers while we try to
create an expensive index for a single big register.

This extracts that code into a new Indexer class, and starts these
indexers in parallel, so that we can start consuming one register while
creating a GIN index on another.

Once this is merged, we can revert #19.
