### PR TITLE
All database queries must be written in lowercase characters

### DIFF
--- a/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
@@ -10,18 +10,18 @@ import java.util.Set;
 
 @UseStringTemplate3StatementLocator
 interface CurrentKeysUpdateDAO extends DBConnectionDAO {
-    String CURRENT_KEYS_TABLE = "CURRENT_KEYS";
+    String CURRENT_KEYS_TABLE = "current_keys";
 
-    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + CURRENT_KEYS_TABLE + " (KEY VARCHAR PRIMARY KEY, SERIAL_NUMBER INTEGER UNIQUE)")
+    @SqlUpdate("create table if not exists " + CURRENT_KEYS_TABLE + " (key varchar primary key, serial_number integer unique)")
     void ensureCurrentKeysTableExists();
 
-    @SqlUpdate("UPDATE " + CURRENT_KEYS_TABLE + " SET SERIAL_NUMBER=:serial_number WHERE KEY=:key")
+    @SqlUpdate("update " + CURRENT_KEYS_TABLE + " set serial_number=:serial_number where key=:key")
     int updateSerialNumber(@Bind("serial_number") int serial_number, @Bind("key") String key);
 
-    @SqlQuery("SELECT KEY FROM " + CURRENT_KEYS_TABLE + " WHERE KEY IN (<keys>)")
+    @SqlQuery("select key from " + CURRENT_KEYS_TABLE + " where key in (<keys>)")
     Set<String> getExistingKeys(@BindIn("keys") Iterable<String> keys);
 
-    @SqlUpdate("INSERT INTO " + CURRENT_KEYS_TABLE + "(SERIAL_NUMBER, KEY) VALUES(:serial_number, :key)")
+    @SqlUpdate("insert into " + CURRENT_KEYS_TABLE + "(serial_number, key) values(:serial_number, :key)")
     void insertNewKey(@Bind("serial_number") int serial_number, @Bind("key") String key);
 }
 

--- a/src/main/java/uk/gov/indexer/dao/SourceDBQueryDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/SourceDBQueryDAO.java
@@ -10,6 +10,6 @@ public interface SourceDBQueryDAO extends DBConnectionDAO {
     String ENTRIES_TABLE = "entries";
 
     @RegisterMapper(EntryMapper.class)
-    @SqlQuery("SELECT ID,ENTRY FROM " + ENTRIES_TABLE + " WHERE ID > :lastReadSerialNumber ORDER BY ID LIMIT 5000")
+    @SqlQuery("select id,entry from " + ENTRIES_TABLE + " where id > :lastreadserialnumber order by id limit 5000")
     List<Entry> read(@Bind("lastReadSerialNumber") int lastReadSerialNumber);
 }

--- a/src/main/java/uk/gov/indexer/dao/TotalRegisterEntriesUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/TotalRegisterEntriesUpdateDAO.java
@@ -6,12 +6,12 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 interface TotalRegisterEntriesUpdateDAO extends DBConnectionDAO {
     String TOTAL_REGISTER_ENTRIES_TABLE = "register_entries_count";
 
-    @SqlUpdate("CREATE TABLE IF NOT EXISTS " + TOTAL_REGISTER_ENTRIES_TABLE + " (COUNT INTEGER)")
+    @SqlUpdate("create table if not exists " + TOTAL_REGISTER_ENTRIES_TABLE + " (count integer)")
     void ensureTotalEntriesInRegisterTableExists();
 
-    @SqlUpdate("INSERT INTO " + TOTAL_REGISTER_ENTRIES_TABLE + "(COUNT) SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM " + TOTAL_REGISTER_ENTRIES_TABLE + ")")
+    @SqlUpdate("insert into " + TOTAL_REGISTER_ENTRIES_TABLE + "(count) select 0 where not exists (select 1 from " + TOTAL_REGISTER_ENTRIES_TABLE + ")")
     void initialiseTotalEntriesInRegisterIfRequired();
 
-    @SqlUpdate("UPDATE " + TOTAL_REGISTER_ENTRIES_TABLE + " SET COUNT=COUNT+:noOfEntries")
+    @SqlUpdate("update " + TOTAL_REGISTER_ENTRIES_TABLE + " set count=count+:noofentries")
     void increaseTotalEntriesInRegisterCount(@Bind("noOfEntries") int noOfEntries);
 }


### PR DESCRIPTION
All queries must be written in lowercase characters to remove any confusion and probable bug.

 Postgres entities are created as all lowercase characters. we faced a problem in indexer app in which where clause was specifying an index name in uppercase and the condition was never met (https://github.com/openregister/indexer/pull/23).
