### PR TITLE
Use trigger to initialise total_entries table

### DIFF
--- a/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
@@ -8,39 +8,12 @@ import org.skife.jdbi.v2.unstable.BindIn;
 
 import java.util.Set;
 
-@UseStringTemplate3StatementLocator
+@UseStringTemplate3StatementLocator("/sql/init_records.sql")
 interface CurrentKeysUpdateDAO extends DBConnectionDAO {
 
     String CURRENT_KEYS_TABLE = "current_keys";
-    String TOTAL_RECORDS_TABLE = "total_records";
-    String TOTAL_RECORDS_FUNCTION = TOTAL_RECORDS_TABLE + "_fn()";
-    String TOTAL_RECORDS_TRIGGER = TOTAL_RECORDS_TABLE + "_trigger";
 
-    @SqlUpdate(
-            "CREATE TABLE IF NOT EXISTS " + CURRENT_KEYS_TABLE + " (KEY VARCHAR PRIMARY KEY, SERIAL_NUMBER INTEGER UNIQUE);" +
-
-                    "CREATE TABLE IF NOT EXISTS " + TOTAL_RECORDS_TABLE + " (COUNT INTEGER);" +
-
-                    //Insert query below initializes the total records for pre existing register by setting the value as no of rows in current_keys table
-                    "INSERT INTO " + TOTAL_RECORDS_TABLE + "(COUNT) SELECT (SELECT COUNT(*) FROM " + CURRENT_KEYS_TABLE + ") WHERE NOT EXISTS(SELECT 1 FROM " + TOTAL_RECORDS_TABLE + ");" +
-
-                    "CREATE OR REPLACE FUNCTION " + TOTAL_RECORDS_FUNCTION + " RETURNS TRIGGER\n" +
-                    "AS $$\n" +
-                    "BEGIN\n" +
-                    "  IF TG_OP = 'INSERT' THEN\n" +
-                    "     EXECUTE 'UPDATE " + TOTAL_RECORDS_TABLE + " SET COUNT=COUNT + 1';\n" +
-                    "     RETURN NEW;\n" +
-                    "  END IF;\n" +
-                    "  RETURN NULL;\n" +
-                    "  END;\n" +
-                    "$$ LANGUAGE plpgsql;" +
-
-                    "DROP TRIGGER IF EXISTS " + TOTAL_RECORDS_TRIGGER + " ON " + CURRENT_KEYS_TABLE + ";" +
-
-                    "CREATE TRIGGER " + TOTAL_RECORDS_TRIGGER + " \n" +
-                    " AFTER INSERT ON " + CURRENT_KEYS_TABLE +
-                    " FOR EACH ROW EXECUTE PROCEDURE " + TOTAL_RECORDS_FUNCTION + ";"
-    )
+    @SqlUpdate
     void ensureRecordTablesInPlace();
 
     @SqlUpdate("UPDATE " + CURRENT_KEYS_TABLE + " SET SERIAL_NUMBER=:serial_number WHERE KEY=:key")

--- a/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
@@ -31,7 +31,7 @@ public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionD
 
         indexedEntriesUpdateDAO = handle.attach(IndexedEntriesUpdateDAO.class);
 
-        indexedEntriesUpdateDAO.ensureIndexedEntriesTableExists();
+        indexedEntriesUpdateDAO.ensureEntryTablesInPlace();
         if (!indexedEntriesUpdateDAO.indexedEntriesIndexExists()) {
             indexedEntriesUpdateDAO.createIndexedEntriesIndex();
         }

--- a/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/DestinationDBUpdateDAO.java
@@ -24,17 +24,17 @@ public abstract class DestinationDBUpdateDAO implements GetHandle, DBConnectionD
 
         currentKeysUpdateDAO = handle.attach(CurrentKeysUpdateDAO.class);
 
+        currentKeysUpdateDAO.ensureRecordTablesInPlace();
+
+        totalRegisterEntriesUpdateDAO.ensureTotalEntriesInRegisterTableExists();
+        totalRegisterEntriesUpdateDAO.initialiseTotalEntriesInRegisterIfRequired();
+
         indexedEntriesUpdateDAO = handle.attach(IndexedEntriesUpdateDAO.class);
 
         indexedEntriesUpdateDAO.ensureIndexedEntriesTableExists();
         if (!indexedEntriesUpdateDAO.indexedEntriesIndexExists()) {
             indexedEntriesUpdateDAO.createIndexedEntriesIndex();
         }
-
-        currentKeysUpdateDAO.ensureRecordTablesInPlace();
-
-        totalRegisterEntriesUpdateDAO.ensureTotalEntriesInRegisterTableExists();
-        totalRegisterEntriesUpdateDAO.initialiseTotalEntriesInRegisterIfRequired();
     }
 
     public int lastReadSerialNumber() {

--- a/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
@@ -2,48 +2,17 @@ package uk.gov.indexer.dao;
 
 import org.skife.jdbi.v2.sqlobject.*;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
 import java.util.List;
 
+@UseStringTemplate3StatementLocator("/sql/init_entries.sql")
 public interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
     String INDEXED_ENTRIES_TABLE = "ordered_entry_index";
     String INDEXED_ENTRIES_INDEX = INDEXED_ENTRIES_TABLE + "_gin";
 
-    String TOTAL_ENTRIES_TABLE = "total_entries";
-
-    String TOTAL_ENTRIES_FUNCTION = TOTAL_ENTRIES_TABLE + "_fn()";
-    String TOTAL_ENTRIES_TRIGGER = TOTAL_ENTRIES_TABLE + "_trigger";
-
-
-    @SqlUpdate(
-            "CREATE TABLE IF NOT EXISTS " + INDEXED_ENTRIES_TABLE + " (serial_number INTEGER PRIMARY KEY, entry JSONB);" +
-
-                    "CREATE TABLE IF NOT EXISTS " + TOTAL_ENTRIES_TABLE + " (count INTEGER, last_updated TIMESTAMP WITHOUT TIME ZONE);" +
-
-                    //Insert query copies the no of entries from register_entries_count table, this query will be deleted when we delete the register_entries_count table
-                    "INSERT INTO " + TOTAL_ENTRIES_TABLE + "(count) SELECT (SELECT count FROM register_entries_count LIMIT 1)  WHERE NOT EXISTS(SELECT 1 FROM " + TOTAL_ENTRIES_TABLE + ");" +
-
-                    //Insert query below initializes the total_entries table by 0 if it is not initialized yet
-                    "INSERT INTO " + TOTAL_ENTRIES_TABLE + "(COUNT) SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM " + TOTAL_ENTRIES_TABLE + ");" +
-
-                    "CREATE OR REPLACE FUNCTION " + TOTAL_ENTRIES_FUNCTION + " RETURNS TRIGGER\n" +
-                    "AS $$\n" +
-                    "BEGIN\n" +
-                    "  IF TG_OP = 'INSERT' THEN\n" +
-                    "     EXECUTE 'UPDATE " + TOTAL_ENTRIES_TABLE + " SET count=count + 1, last_updated=now()';\n" +
-                    "     RETURN NEW;\n" +
-                    "  END IF;\n" +
-                    "  RETURN NULL;\n" +
-                    "  END;\n" +
-                    "$$ LANGUAGE plpgsql;" +
-
-                    "DROP TRIGGER IF EXISTS " + TOTAL_ENTRIES_TRIGGER + " ON " + INDEXED_ENTRIES_TABLE + ";" +
-
-                    "CREATE TRIGGER " + TOTAL_ENTRIES_TRIGGER + " \n" +
-                    " AFTER INSERT ON " + INDEXED_ENTRIES_TABLE +
-                    " FOR EACH ROW EXECUTE PROCEDURE " + TOTAL_ENTRIES_FUNCTION + ";"
-    )
-    void ensureIndexedEntriesTableExists();
+    @SqlUpdate
+    void ensureEntryTablesInPlace();
 
     @SqlUpdate("CREATE INDEX " + INDEXED_ENTRIES_INDEX + " ON " + INDEXED_ENTRIES_TABLE + " USING gin(entry jsonb_path_ops)")
     void createIndexedEntriesIndex();

--- a/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
@@ -18,7 +18,7 @@ public interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
     @SqlUpdate(
             "CREATE TABLE IF NOT EXISTS " + INDEXED_ENTRIES_TABLE + " (serial_number INTEGER PRIMARY KEY, entry JSONB);" +
 
-                    "CREATE TABLE IF NOT EXISTS " + TOTAL_ENTRIES_TABLE + " (count INTEGER);" +
+                    "CREATE TABLE IF NOT EXISTS " + TOTAL_ENTRIES_TABLE + " (count INTEGER, last_updated TIMESTAMP WITHOUT TIME ZONE);" +
 
                     //Insert query copies the no of entries from register_entries_count table, this query will be deleted when we delete the register_entries_count table
                     "INSERT INTO " + TOTAL_ENTRIES_TABLE + "(count) SELECT (SELECT count FROM register_entries_count LIMIT 1)  WHERE NOT EXISTS(SELECT 1 FROM " + TOTAL_ENTRIES_TABLE + ");" +
@@ -30,7 +30,7 @@ public interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
                     "AS $$\n" +
                     "BEGIN\n" +
                     "  IF TG_OP = 'INSERT' THEN\n" +
-                    "     EXECUTE 'UPDATE " + TOTAL_ENTRIES_TABLE + " SET COUNT=COUNT + 1';\n" +
+                    "     EXECUTE 'UPDATE " + TOTAL_ENTRIES_TABLE + " SET count=count + 1, last_updated=now()';\n" +
                     "     RETURN NEW;\n" +
                     "  END IF;\n" +
                     "  RETURN NULL;\n" +

--- a/src/main/resources/sql/init_entries.sql
+++ b/src/main/resources/sql/init_entries.sql
@@ -1,0 +1,31 @@
+group DAO;
+
+ensureEntryTablesInPlace() ::= <<
+
+CREATE TABLE IF NOT EXISTS   ordered_entry_index   (serial_number INTEGER PRIMARY KEY, entry JSONB);
+
+CREATE TABLE IF NOT EXISTS   total_entries   (count INTEGER, last_updated TIMESTAMP WITHOUT TIME ZONE);
+
+--Insert query copies the no of entries from register_entries_count table, this query will be deleted when we delete the register_entries_count table
+INSERT INTO   total_entries  (count) SELECT (SELECT count FROM register_entries_count LIMIT 1)  WHERE NOT EXISTS(SELECT 1 FROM   total_entries  );
+
+--Insert query below initializes the total_entries table by 0 if it is not initialized yet
+INSERT INTO   total_entries  (COUNT) SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM   total_entries  );
+
+CREATE OR REPLACE FUNCTION   total_entries_fn()   RETURNS TRIGGER
+AS $$ 
+BEGIN 
+  IF TG_OP = 'INSERT' THEN 
+     EXECUTE 'UPDATE   total_entries   SET count=count + 1, last_updated=now()';
+     RETURN NEW; 
+  END IF; 
+  RETURN NULL; 
+  END; 
+$$ LANGUAGE plpgsql; 
+
+DROP TRIGGER IF EXISTS   total_entries_trigger   ON   ordered_entry_index  ;
+
+CREATE TRIGGER   total_entries_trigger
+ AFTER INSERT ON   ordered_entry_index
+ FOR EACH ROW EXECUTE PROCEDURE   total_entries_fn()  ;
+>>

--- a/src/main/resources/sql/init_records.sql
+++ b/src/main/resources/sql/init_records.sql
@@ -1,0 +1,27 @@
+group DAO;
+
+ensureRecordTablesInPlace() ::= <<
+CREATE TABLE IF NOT EXISTS  current_keys  (KEY VARCHAR PRIMARY KEY, SERIAL_NUMBER INTEGER UNIQUE);
+
+CREATE TABLE IF NOT EXISTS  total_records  (COUNT INTEGER);
+
+--Insert query below initializes the total records for pre existing register by setting the value as no of rows in current_keys table
+INSERT INTO  total_records (COUNT) SELECT (SELECT COUNT(*) FROM  current_keys) WHERE NOT EXISTS(SELECT 1 FROM  total_records );
+
+CREATE OR REPLACE FUNCTION  total_records_fn() RETURNS TRIGGER
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+     EXECUTE 'UPDATE total_records SET count=count + 1';
+     RETURN NEW;
+  END IF;
+  RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS total_records_trigger ON  current_keys ;
+
+CREATE TRIGGER  total_records_trigger
+ AFTER INSERT ON  current_keys
+ FOR EACH ROW EXECUTE PROCEDURE  total_records_fn() ;
+>>


### PR DESCRIPTION
NOTE: It is recommended to merge this PR after https://github.com/openregister/indexer/pull/25

Changes in this PR create a new table named as total_entries which contains number of all entries in register. Although we have an existing table "register_entries_count" which contains the exact same number but in PR (https://github.com/openregister/indexer/pull/25) we created a new table named as 'total_records' to keep track of all records in register. this PR uses trigger to update the count. Changes here makes the process of keeping no of entries consistent with PR(https://github.com/openregister/indexer/pull/25).

The new total_entries table also contains a column last_updated register time.

When the presentation app start using total_entries table we will remove TotalRegisterEntriesUpdateDAO class and its respective code.
