### PR TITLE
Upload to elasticsearch domain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-    compile postgresClient, jdbi, aws_cloudsearch, stringTemplate
-    testCompile junit, mockito
+    compile postgresClient, jdbi, aws_cloudsearch, jersey_client, stringTemplate
+    testCompile junit, mockito, wiremock
 }
 
 jar.baseName = "indexer"

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -4,8 +4,10 @@ ext {
     jdbi = 'org.jdbi:jdbi:2.63.1'
     stringTemplate= 'org.antlr:stringtemplate:3.2.1'
     aws_cloudsearch = 'com.amazonaws:aws-java-sdk-cloudsearch:1.10.22'
+    jersey_client = 'org.glassfish.jersey.core:jersey-client:2.22.1'
 
     //test dependency
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.9.5'
+    wiremock = 'com.github.tomakehurst:wiremock:2.0.8-beta'
 }

--- a/src/main/java/uk/gov/indexer/Application.java
+++ b/src/main/java/uk/gov/indexer/Application.java
@@ -11,7 +11,7 @@ public class Application {
         Configuration configuration = new Configuration(args);
         Set<String> registers = configuration.getRegisters();
 
-        ScheduledExecutorService executorService = Executors.newScheduledThreadPool((int) registers.stream().filter(r -> configuration.cloudSearchEndPoint(r).isPresent()).count() + registers.size());
+        ScheduledExecutorService executorService = Executors.newScheduledThreadPool((int) registers.stream().filter(r -> configuration.cloudSearchEndPoint(r).isPresent() || configuration.elasticSerachEndPoint(r).isPresent()).count() + registers.size());
 
         List<Indexer> indexers = registers.stream().map(r -> new Indexer(configuration, r)).collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/indexer/Configuration.java
+++ b/src/main/java/uk/gov/indexer/Configuration.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 class Configuration {
     private final Set<String> registers;
     private final Properties properties;
+    private final Map<String, String> elasticSearchEndPoints;
     private final Map<String, String> cloudSearchEndPoints;
     private final Map<String, String> cloudSearchWatermarkEndPoints;
 
@@ -18,14 +19,15 @@ class Configuration {
             this.properties = new Properties();
             properties.load(configurationPropertiesStream(createConfigurationMap(args).get("config.file")));
             this.registers = extractConfiguredRegisters();
-            this.cloudSearchEndPoints = createCloudSearchEndPoints(".cloudsearch.search.endpoint");
-            this.cloudSearchWatermarkEndPoints = createCloudSearchEndPoints(".cloudsearch.highwatermark.endpoint");
+            this.elasticSearchEndPoints = createSearchEndPoints(".elasticsearch.endpoint");
+            this.cloudSearchEndPoints = createSearchEndPoints(".cloudsearch.search.endpoint");
+            this.cloudSearchWatermarkEndPoints = createSearchEndPoints(".cloudsearch.highwatermark.endpoint");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private Map<String, String> createCloudSearchEndPoints(String keyEndsWithString) {
+    private Map<String, String> createSearchEndPoints(String keyEndsWithString) {
         return properties.keySet()
                 .stream()
                 .map(Object::toString)
@@ -76,5 +78,9 @@ class Configuration {
 
     public Optional<String> cloudSearchWaterMarkEndPoint(String register) {
         return Optional.ofNullable(cloudSearchWatermarkEndPoints.get(register));
+    }
+
+    public Optional<String> elasticSerachEndPoint(String register) {
+        return Optional.ofNullable(elasticSearchEndPoints.get(register));
     }
 }

--- a/src/main/java/uk/gov/indexer/ElasticSearch.java
+++ b/src/main/java/uk/gov/indexer/ElasticSearch.java
@@ -1,0 +1,105 @@
+package uk.gov.indexer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import uk.gov.indexer.dao.OrderedEntryIndex;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+public class ElasticSearch {
+    private final String register;
+    private final JerseyClient client;
+    private final String searchDomainEndPoint;
+
+    public ElasticSearch(String register, String searchDomainEndPoint) {
+        this.searchDomainEndPoint = searchDomainEndPoint;
+        this.client = JerseyClientBuilder.createClient(new ClientConfig());
+        this.register = register;
+    }
+
+    public void upload(List<OrderedEntryIndex> entries) {
+
+        entries.forEach(entry -> {
+
+            Map<String, ?> uploadRequest = uploadRequest(entry);
+
+            String entryPrimaryKey = (String) ((Map) uploadRequest.get("entry")).get(register);
+
+            String requestUri = String.format("%s/%s/records/%s", searchDomainEndPoint, register, entryPrimaryKey);
+
+            Response response = makeRequest(requestUri, uploadRequest);
+
+
+            if (Response.Status.Family.SUCCESSFUL != Response.Status.fromStatusCode(response.getStatus()).getFamily()) {
+                throw new RuntimeException(
+                        String.format(
+                                "Error while loading entry to elasticsearch for register: '%s'. error entry serial_number is: '%s' and entry is: '%s'",
+                                register,
+                                entry.getSerial_number(),
+                                entry.getEntry()
+                        )
+                );
+            }
+        });
+    }
+
+    public int currentWaterMark() {
+        String requestUri = String.format("%s/%s/records/_search", searchDomainEndPoint, register);
+
+        Response response = makeRequest(requestUri, highestSerialNumberSearchRequest());
+
+        //note: 404 will be returned when requested index is not exists.
+        //we are returning 0 which confirms that there is no entry and the index will be created when first entry is uploaded.
+        if (response.getStatus() == 404) {
+            return 0;
+        }
+
+        if (response.getStatus() == 200) {
+            JsonNode responseJson = JsonUtils.fromJsonString(response.readEntity(String.class), JsonNode.class);
+
+            if (responseJson.get("hits").get("total").intValue() == 0) {
+                return 0;
+            }
+
+            return responseJson.get("hits").get("hits").get(0).get("_source").get("serial_number").intValue();
+        }
+
+        throw new RuntimeException("Unexpected response from elasticsearch request. statusCode: " + response.getStatus() + ", response body: " + response.readEntity(String.class));
+    }
+
+    private Response makeRequest(String requestUri, Map<String, ?> entity) {
+        return client
+                .target(requestUri)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(JsonUtils.toJsonString(entity), MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    private Map<String, ?> highestSerialNumberSearchRequest() {
+        return ImmutableMap.of(
+                "filter", ImmutableMap.of(
+                        "match_all", ImmutableMap.of()
+                ),
+                "sort", ImmutableMap.of(
+                        "serial_number", ImmutableMap.of(
+                                "order", "desc"
+                        )
+                ),
+                "size", 1
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, ?> uploadRequest(OrderedEntryIndex orderedEntryIndex) {
+        Map requestMap = JsonUtils.fromJsonString(orderedEntryIndex.getEntry(), Map.class);
+        requestMap.put("serial_number", orderedEntryIndex.getSerial_number());
+        return requestMap;
+    }
+}
+

--- a/src/main/java/uk/gov/indexer/ElasticSearchDataUploadTask.java
+++ b/src/main/java/uk/gov/indexer/ElasticSearchDataUploadTask.java
@@ -1,0 +1,40 @@
+package uk.gov.indexer;
+
+import com.google.common.collect.Iterables;
+import uk.gov.indexer.dao.IndexedEntriesUpdateDAO;
+import uk.gov.indexer.dao.OrderedEntryIndex;
+
+import java.util.List;
+
+public class ElasticSearchDataUploadTask implements Runnable {
+    private final ElasticSearch elasticsearch;
+    private final String register;
+    private final IndexedEntriesUpdateDAO indexedEntriesUpdateDAO;
+
+    public ElasticSearchDataUploadTask(String register, String searchDomainEndPoint, IndexedEntriesUpdateDAO indexedEntriesUpdateDAO) {
+        this.register = register;
+        this.indexedEntriesUpdateDAO = indexedEntriesUpdateDAO;
+        this.elasticsearch = new ElasticSearch(register, searchDomainEndPoint);
+    }
+
+    @Override
+    public void run() {
+        try {
+            ConsoleLogger.log("Starting upload to elasticsearch domain for register: " + register);
+            uploadEntries();
+            ConsoleLogger.log("upload to elasticsearch domain completed for register: " + register);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    private void uploadEntries() {
+        List<OrderedEntryIndex> entries;
+        int currentWatermark = elasticsearch.currentWaterMark();
+        while (!(entries = indexedEntriesUpdateDAO.fetchEntriesAfter(currentWatermark)).isEmpty()) {
+            elasticsearch.upload(entries);
+            currentWatermark = Iterables.getLast(entries).getSerial_number();
+        }
+    }
+}

--- a/src/main/java/uk/gov/indexer/ElasticSearchTest.java
+++ b/src/main/java/uk/gov/indexer/ElasticSearchTest.java
@@ -1,0 +1,145 @@
+package uk.gov.indexer;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.indexer.dao.OrderedEntryIndex;
+
+import javax.ws.rs.core.MediaType;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ElasticSearchTest {
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(9111);
+
+    private ElasticSearch elasticSearch = new ElasticSearch("register", "http://localhost:9111");
+
+    @Test
+    public void currentWaterMark_returns0WhenNoIndexIsAvailableForRegister() {
+        stubFor(
+                post(urlPathEqualTo("/register/records/_search"))
+                        .withRequestBody(equalToJson("{\"filter\":{\"match_all\":{}}, \"sort\":{\"serial_number\":{\"order\":\"desc\"}}, \"size\": 1}"))
+                        .willReturn(
+                                ResponseDefinitionBuilder.responseDefinition()
+                                        .withStatus(404)
+                        )
+        );
+
+        assertThat(elasticSearch.currentWaterMark(), equalTo(0));
+    }
+
+    @Test
+    public void currentWaterMark_returns0WhenIndexIsAvailableButNoEntryExists() {
+        stubFor(
+                post(urlPathEqualTo("/register/records/_search"))
+                        .withRequestBody(equalToJson("{\"filter\":{\"match_all\":{}}, \"sort\":{\"serial_number\":{\"order\":\"desc\"}}, \"size\": 1}"))
+                        .willReturn(
+                                ResponseDefinitionBuilder.responseDefinition()
+                                        .withBody("{'took':1,'timed_out':false,'_shards':{'total':5,'successful':5,'failed':0},'hits':{'total':0,'max_score':null,'hits':[]}}".replaceAll("'", "\""))
+                                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                                        .withStatus(200)
+                        )
+        );
+
+        assertThat(elasticSearch.currentWaterMark(), equalTo(0));
+    }
+
+    @Test
+    public void currentWaterMark_returnsTheHighestSerialNumberOfAllEntries() {
+
+        stubFor(
+                post(urlPathEqualTo("/register/records/_search"))
+                        .withRequestBody(equalToJson("{\"filter\":{\"match_all\":{}}, \"sort\":{\"serial_number\":{\"order\":\"desc\"}}, \"size\": 1}"))
+                        .willReturn(
+                                ResponseDefinitionBuilder.responseDefinition()
+                                        .withBody("{'took':1,'timed_out':false,'_shards':{'total':5,'successful':5,'failed':0},'hits':{'total':1,'max_score':null,'hits':[{'_index':'register','_type':'records','_id':'foo','_score':1.0,'_source':{'serial_number': 5, 'hash':'hashvalue', 'entry': {'register':'foo', 'text':'textvalue'}}}]}}".replaceAll("'", "\""))
+                                        .withHeader("Content-Type", MediaType.APPLICATION_JSON)
+                                        .withStatus(200)
+                        )
+        );
+
+
+        assertThat(elasticSearch.currentWaterMark(), equalTo(5));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void currentWaterMark_throwsRuntimeExceptionWhenESReturnsNon200OrNon404Response() {
+        stubFor(
+                post(urlPathEqualTo("/register/records/_search"))
+                        .withRequestBody(equalToJson("{\"filter\":{\"match_all\":{}}, \"sort\":{\"serial_number\":{\"order\":\"desc\"}}, \"size\": 1}"))
+                        .willReturn(
+                                ResponseDefinitionBuilder.responseDefinition()
+                                        .withStatus(500)
+                        )
+        );
+
+        elasticSearch.currentWaterMark();
+    }
+
+    @Test
+    public void upload_postsAllEntriesToElasticSearchDomain() {
+        stubFor(
+                post(urlPathEqualTo("/register/records/foo1"))
+                        .withRequestBody(equalToJson("{\"serial_number\":1, \"hash\":\"hashValue1\", \"entry\":{\"register\":\"foo1\", \"text\":\"textValue1\"}}"))
+                        .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(201))
+        );
+
+        stubFor(
+                post(urlPathEqualTo("/register/records/foo2"))
+                        .withRequestBody(equalToJson("{\"serial_number\":2,\"hash\":\"hashValue2\", \"entry\":{\"register\":\"foo2\", \"text\":\"textValue2\"}}"))
+                        .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(201))
+        );
+
+        stubFor(
+                post(urlPathEqualTo("/register/records/foo1"))
+                        .withRequestBody(equalToJson("{\"serial_number\":3,\"hash\":\"hashValue3\", \"entry\":{\"register\":\"foo1\", \"text\":\"updatetextValue\"}}"))
+                        .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(200))
+        );
+
+        List<OrderedEntryIndex> entries = Arrays.asList(
+                new OrderedEntryIndex(1, "{\"hash\":\"hashValue1\", \"entry\":{\"register\":\"foo1\", \"text\":\"textValue1\"}}"),
+                new OrderedEntryIndex(2, "{\"hash\":\"hashValue2\", \"entry\":{\"register\":\"foo2\", \"text\":\"textValue2\"}}"),
+                new OrderedEntryIndex(3, "{\"hash\":\"hashValue3\", \"entry\":{\"register\":\"foo1\", \"text\":\"updatetextValue\"}}")
+        );
+
+        elasticSearch.upload(entries);
+    }
+
+
+    @Test
+    public void upload_throwsRuntimeExceptionWhenAnyEntryUploadIsNotSuccessful() {
+        stubFor(
+                post(urlPathEqualTo("/register/records/foo1"))
+                        .withRequestBody(equalToJson("{\"serial_number\":1, \"hash\":\"hashValue1\", \"entry\":{\"register\":\"foo1\", \"text\":\"textValue1\"}}"))
+                        .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(201))
+        );
+
+        stubFor(
+                post(urlPathEqualTo("/register/records/foo2"))
+                        .withRequestBody(equalToJson("{\"serial_number\":2,\"hash\":\"hashValue2\", \"entry\":{\"register\":\"foo2\", \"text\":\"textValue2\"}}"))
+                        .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(400))
+        );
+
+        List<OrderedEntryIndex> entries = Arrays.asList(
+                new OrderedEntryIndex(1, "{\"hash\":\"hashValue1\", \"entry\":{\"register\":\"foo1\", \"text\":\"textValue1\"}}"),
+                new OrderedEntryIndex(2, "{\"hash\":\"hashValue2\", \"entry\":{\"register\":\"foo2\", \"text\":\"textValue2\"}}")
+        );
+
+        try {
+            elasticSearch.upload(entries);
+            fail("must throw exception");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), containsString("serial_number is: 2"));
+        }
+    }
+}

--- a/src/main/java/uk/gov/indexer/Indexer.java
+++ b/src/main/java/uk/gov/indexer/Indexer.java
@@ -45,6 +45,15 @@ public class Indexer {
                     )
             );
 
+            configuration.elasticSerachEndPoint(register).ifPresent(
+                    endPoint -> executorService.scheduleAtFixedRate(
+                            new ElasticSearchDataUploadTask(register, endPoint, destDbi.onDemand(IndexedEntriesUpdateDAO.class)),
+                            0,
+                            5,
+                            TimeUnit.MINUTES
+                    )
+            );
+
         } catch (Throwable e) {
             e.printStackTrace();
             ConsoleLogger.log("Error occurred while setting indexer for register: " + register + ". Error is -> " + e.getMessage());

--- a/src/main/java/uk/gov/indexer/JsonUtils.java
+++ b/src/main/java/uk/gov/indexer/JsonUtils.java
@@ -1,0 +1,28 @@
+package uk.gov.indexer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+public class JsonUtils{
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> T fromJsonString(String content, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(content, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String toJsonString(Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-field.source.postgres.db.connectionString=jdbc:postgresql://localhost:5432/field?user=postgres
-field.destination.postgres.db.connectionString=jdbc:postgresql://localhost:5432/field?user=postgres
+address.source.postgres.db.connectionString=jdbc:postgresql://localhost:5432/address?user=postgres
+address.destination.postgres.db.connectionString=jdbc:postgresql://localhost:5432/address?user=postgres
 
-#address.cloudsearch.search.endpoint=ConfigureSearchDomainEndPointForTheRegister
-#address.cloudsearch.highwatermark.endpoint=ConfigureHighwatermarkEndPointForRegister
+address.cloudsearch.search.endpoint=ConfigureSearchDomainEndPointForTheRegister
+address.cloudsearch.highwatermark.endpoint=ConfigureHighwatermarkEndPointForRegister
 
-field.elasticsearch.endpoint=ConfigureElasticSearchEndpointUrl
+address.elasticsearch.endpoint=ConfigureElasticSearchEndpointUrl_must_start_with_http_or_https

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
-address.source.postgres.db.connectionString=jdbc:postgresql://localhost:5432/address?user=postgres
-address.destination.postgres.db.connectionString=jdbc:postgresql://localhost:5432/address?user=postgres
+field.source.postgres.db.connectionString=jdbc:postgresql://localhost:5432/field?user=postgres
+field.destination.postgres.db.connectionString=jdbc:postgresql://localhost:5432/field?user=postgres
 
-address.cloudsearch.search.endpoint=ConfigureSearchDomainEndPointForTheRegister
-address.cloudsearch.highwatermark.endpoint=ConfigureHighwatermarkEndPointForRegister
+#address.cloudsearch.search.endpoint=ConfigureSearchDomainEndPointForTheRegister
+#address.cloudsearch.highwatermark.endpoint=ConfigureHighwatermarkEndPointForRegister
+
+field.elasticsearch.endpoint=ConfigureElasticSearchEndpointUrl

--- a/src/test/java/uk/gov/indexer/ElasticSearchTest.java
+++ b/src/test/java/uk/gov/indexer/ElasticSearchTest.java
@@ -139,7 +139,7 @@ public class ElasticSearchTest {
             elasticSearch.upload(entries);
             fail("must throw exception");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), containsString("serial_number is: 2"));
+            assertThat(e.getMessage(), containsString("serial_number is: '2'"));
         }
     }
 }


### PR DESCRIPTION
We are using aws cloudsearch to provide text search capability for some registers. Going forward the plan is to replace cloudsearch by aws elasticsearch service. Added capability in indexer to upload entries in elastic search domain.
