### PR TITLE
Serial number should be the zero-based index to match the CTServer.

### DIFF
--- a/src/main/java/uk/gov/indexer/fetchers/CTDataSource.java
+++ b/src/main/java/uk/gov/indexer/fetchers/CTDataSource.java
@@ -31,7 +31,7 @@ public class CTDataSource implements DataSource {
                 return ctServer.getEntries(from, lastEntryNumber - 1 )
                         .entries
                         .stream()
-                        .map(ctEntryLeaf -> createEntry(atomicInteger.incrementAndGet(), ctEntryLeaf.getPayload(), ctEntryLeaf.getLeafInput()))
+                        .map(ctEntryLeaf -> createEntry(atomicInteger.getAndIncrement(), ctEntryLeaf.getPayload(), ctEntryLeaf.getLeafInput()))
                         .collect(Collectors.toList());
             }
             return new ArrayList<>();


### PR DESCRIPTION
Caused by the AtomicInteger using preincrement (serial number is 1-based, rather than 0-based).
