### PR TITLE
Indexer fails to copy single entries from CTServer.

### DIFF
--- a/src/main/java/uk/gov/indexer/fetchers/CTDataSource.java
+++ b/src/main/java/uk/gov/indexer/fetchers/CTDataSource.java
@@ -31,7 +31,7 @@ public class CTDataSource implements DataSource {
                 return ctServer.getEntries(from, lastEntryNumber - 1 )
                         .entries
                         .stream()
-                        .map(ctEntryLeaf -> createEntry(atomicInteger.incrementAndGet(), ctEntryLeaf.getPayload(), ctEntryLeaf.getLeafInput()))
+                        .map(ctEntryLeaf -> createEntry(atomicInteger.getAndIncrement(), ctEntryLeaf.getPayload(), ctEntryLeaf.getLeafInput()))
                         .collect(Collectors.toList());
             }
             return new ArrayList<>();

--- a/src/test/java/uk/gov/indexer/IndexerTaskTest.java
+++ b/src/test/java/uk/gov/indexer/IndexerTaskTest.java
@@ -146,7 +146,7 @@ public class IndexerTaskTest {
             resultSet.next();
             assertThat(resultSet.getInt("count"), CoreMatchers.equalTo(expectedEntries));
         }
-        try (ResultSet resultSet = statement.executeQuery("select leaf_input from ordered_entry_index where serial_number=" + expectedEntries)) {
+        try (ResultSet resultSet = statement.executeQuery("select leaf_input from ordered_entry_index where serial_number=" + (expectedEntries-1))) {
             resultSet.next();
             assertFalse(resultSet.getString("leaf_input").isEmpty());
         }

--- a/src/test/java/uk/gov/indexer/fetchers/CTDataSourceTest.java
+++ b/src/test/java/uk/gov/indexer/fetchers/CTDataSourceTest.java
@@ -42,7 +42,7 @@ public class CTDataSourceTest {
         assertThat(result.size(), equalTo(2));
 
         Entry entry1 = result.get(0);
-        assertThat(entry1.serial_number, equalTo(11));
+        assertThat(entry1.serial_number, equalTo(10));
 
         JsonNode node1 = JsonUtils.fromBytesToJsonNode(entry1.contents);
         byte[] expectedItemBytes1 = "{ \"owner\": \"Veterinary Medicines Directorate\", \"end-date\": \"\", \"government-domain\": \"ami.gov.uk\" }".getBytes();
@@ -50,7 +50,7 @@ public class CTDataSourceTest {
         assertThat(node1.get("hash").textValue(), equalTo(SHA256Hash.createHash(expectedItemBytes1)));
 
         Entry entry2 = result.get(1);
-        assertThat(entry2.serial_number, equalTo(12));
+        assertThat(entry2.serial_number, equalTo(11));
 
         JsonNode node2 = JsonUtils.fromBytesToJsonNode(entry2.contents);
         byte[] expectedItemBytes2 = "{ \"owner\": \"Andover Town Council\", \"end-date\": \"\", \"government-domain\": \"andover-tc.gov.uk\" }".getBytes();


### PR DESCRIPTION
Caused by an off-by-one error (STH reports a count of entries, but the entries are 0-based). 
