### PR TITLE
Remove triggers

### DIFF
--- a/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/CurrentKeysUpdateDAO.java
@@ -1,5 +1,6 @@
 package uk.gov.indexer.dao;
 
+import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
@@ -15,9 +16,12 @@ interface CurrentKeysUpdateDAO extends DBConnectionDAO {
     void ensureRecordTablesInPlace();
 
     @SqlUpdate("delete from " + CURRENT_KEYS_TABLE + " where key in (<keys>)")
-    void removeRecordWithKeys(@BindIn("keys") Iterable<String> allKeys);
+    int removeRecordWithKeys(@BindIn("keys") Iterable<String> allKeys);
 
     @SqlBatch("insert into " + CURRENT_KEYS_TABLE + "(serial_number, key) values(:serial_number, :key)")
     void writeCurrentKeys(@BindBean Iterable<CurrentKey> values);
+
+    @SqlUpdate("update total_records set count=count+:noOfNewRecords")
+    void updateTotalRecords(@Bind("noOfNewRecords") int noOfNewRecords);
 }
 

--- a/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/IndexedEntriesUpdateDAO.java
@@ -34,6 +34,9 @@ public interface IndexedEntriesUpdateDAO extends DBConnectionDAO {
     @SqlQuery("SELECT * FROM " + INDEXED_ENTRIES_TABLE + " WHERE serial_number > :serial_number ORDER BY serial_number LIMIT 5000")
     List<OrderedEntryIndex> fetchEntriesAfter(@Bind("serial_number") int watermark);
 
+    @SqlUpdate("update total_entries set count=count+:entriesWritten, last_updated=now()")
+    void updateTotalEntries(@Bind("entriesWritten") long entriesWritten);
+
     class OrderedEntryIndexMapper implements ResultSetMapper<OrderedEntryIndex> {
         @Override
         public OrderedEntryIndex map(int index, ResultSet r, StatementContext ctx) throws SQLException {

--- a/src/main/resources/sql/init_entries.sql
+++ b/src/main/resources/sql/init_entries.sql
@@ -11,20 +11,8 @@ CREATE TABLE IF NOT EXISTS   total_entries   (count INTEGER, last_updated TIMEST
 --Insert query below initializes the total_entries table by 0 if it is not initialized yet
 INSERT INTO   total_entries  (COUNT) SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM   total_entries  );
 
-CREATE OR REPLACE FUNCTION   total_entries_fn()   RETURNS TRIGGER
-AS $$ 
-BEGIN 
-  IF TG_OP = 'INSERT' THEN 
-     EXECUTE 'UPDATE   total_entries   SET count=count + 1, last_updated=now()';
-     RETURN NEW; 
-  END IF; 
-  RETURN NULL; 
-  END; 
-$$ LANGUAGE plpgsql; 
+DROP TRIGGER IF EXISTS total_entries_trigger ON  ordered_entry_index ;
 
-DROP TRIGGER IF EXISTS   total_entries_trigger   ON   ordered_entry_index  ;
+DROP FUNCTION IF EXISTS total_entries_fn();
 
-CREATE TRIGGER   total_entries_trigger
- AFTER INSERT ON   ordered_entry_index
- FOR EACH ROW EXECUTE PROCEDURE   total_entries_fn()  ;
 >>

--- a/src/main/resources/sql/init_records.sql
+++ b/src/main/resources/sql/init_records.sql
@@ -8,20 +8,8 @@ CREATE TABLE IF NOT EXISTS  total_records  (COUNT INTEGER);
 --Insert query below initializes the total records for pre existing register by setting the value as no of rows in current_keys table
 INSERT INTO  total_records (COUNT) SELECT (SELECT COUNT(*) FROM  current_keys) WHERE NOT EXISTS(SELECT 1 FROM  total_records );
 
-CREATE OR REPLACE FUNCTION  total_records_fn() RETURNS TRIGGER
-AS $$
-BEGIN
-  IF TG_OP = 'INSERT' THEN
-     EXECUTE 'UPDATE total_records SET count=count + 1';
-     RETURN NEW;
-  END IF;
-  RETURN NULL;
-  END;
-$$ LANGUAGE plpgsql;
-
 DROP TRIGGER IF EXISTS total_records_trigger ON  current_keys ;
 
-CREATE TRIGGER  total_records_trigger
- AFTER INSERT ON  current_keys
- FOR EACH ROW EXECUTE PROCEDURE  total_records_fn() ;
+DROP FUNCTION IF EXISTS total_records_fn();
+
 >>

--- a/src/test/java/uk/gov/indexer/IndexerTaskTest.java
+++ b/src/test/java/uk/gov/indexer/IndexerTaskTest.java
@@ -134,6 +134,7 @@ public class IndexerTaskTest {
 
                 runIndexerAndVerifyResult(statement, indexerTask, 1);
                 assertThat(currentKeys(statement).toString(), CoreMatchers.equalTo("[{1,fp_1}]"));
+                assertNoOfRecordsAndEntries(statement, 1, 1);
 
                 inOrder.verify(cloudwatchRecordsProcessedUpdater).update(1);
 
@@ -142,6 +143,7 @@ public class IndexerTaskTest {
 
                 runIndexerAndVerifyResult(statement, indexerTask, 2);
                 assertThat(currentKeys(statement).toString(), CoreMatchers.equalTo("[{2,fp_1}]"));
+                assertNoOfRecordsAndEntries(statement, 2, 1);
 
                 inOrder.verify(cloudwatchRecordsProcessedUpdater).update(1);
 
@@ -150,6 +152,7 @@ public class IndexerTaskTest {
 
                 runIndexerAndVerifyResult(statement, indexerTask, 7);
                 assertThat(currentKeys(statement).toString(), CoreMatchers.equalTo("[{7,fp_5}, {3,fp_1}, {4,fp_2}, {5,fp_3}, {6,fp_4}]"));
+                assertNoOfRecordsAndEntries(statement, 7, 5);
 
                 inOrder.verify(cloudwatchRecordsProcessedUpdater).update(5);
 
@@ -158,6 +161,7 @@ public class IndexerTaskTest {
 
                 runIndexerAndVerifyResult(statement, indexerTask, 8);
                 assertThat(currentKeys(statement).toString(), CoreMatchers.equalTo("[{7,fp_5}, {4,fp_2}, {5,fp_3}, {6,fp_4}, {8,fp_1}]"));
+                assertNoOfRecordsAndEntries(statement, 8, 5);
 
                 inOrder.verify(cloudwatchRecordsProcessedUpdater).update(1);
 
@@ -168,7 +172,6 @@ public class IndexerTaskTest {
             }
         }
     }
-
 
     @Test
     public void confirmThatCurrentkeyTableLoadsOnlyLatestRecord() throws SQLException {
@@ -228,6 +231,18 @@ public class IndexerTaskTest {
         try (ResultSet resultSet = statement.executeQuery("select count(*) from ordered_entry_index")) {
             resultSet.next();
             assertThat(resultSet.getInt("count"), CoreMatchers.equalTo(expectedEntries));
+        }
+    }
+
+    private void assertNoOfRecordsAndEntries(Statement statement, int entries, int records) throws SQLException {
+        try (ResultSet resultSet = statement.executeQuery("select count from total_entries")) {
+            resultSet.next();
+            assertThat(resultSet.getInt("count"), CoreMatchers.equalTo(entries));
+        }
+
+        try (ResultSet resultSet = statement.executeQuery("select count from total_records")) {
+            resultSet.next();
+            assertThat(resultSet.getInt("count"), CoreMatchers.equalTo(records));
         }
     }
 


### PR DESCRIPTION
Use explicit queries to update total_entries and total_records tables instead of using trigger.

use of trigger was very slow specially for large registers like address. it is advised not to use triggers when loading large data.
