### PR TITLE
Added info log to track the progress of indexer task

### DIFF
--- a/src/main/java/uk/gov/indexer/IndexerTask.java
+++ b/src/main/java/uk/gov/indexer/IndexerTask.java
@@ -44,9 +44,17 @@ public class IndexerTask implements Runnable {
             updateCloudWatch(0);
         } else {
             do {
+                int totalNewEntries = entries.size();
+
+                LOGGER.info(String.format("Register '%s': Found '%s' new entries.", register, totalNewEntries));
+
                 destinationDBUpdateDAO.writeEntriesInBatch(register, entries);
-                LOGGER.info(String.format("Register '%s': Written %s entries from index '%s'.", register, entries.size(), entries.get(0).serial_number));
-                updateCloudWatch(entries.size());
+
+                LOGGER.info(String.format("Register '%s': Copied '%s' entries in database from index '%s'.", register, totalNewEntries, entries.get(0).serial_number));
+
+                updateCloudWatch(totalNewEntries);
+
+                LOGGER.info(String.format("Register '%s': Notified Cloudwatch about '%s' entries processed.", register, totalNewEntries));
             } while (!(entries = fetchNewEntries()).isEmpty());
         }
 


### PR DESCRIPTION
Indexing of address register is very inconsistent. Sometimes It takes a pause for more than one minute in between indexing. Adding more logging to keep track of indexing progress so that the time taken by intermediate steps in indexer task can be analysed.
