### PR TITLE
Upgrade postgres to 9.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - oraclejdk8
 services: 
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 cache:
   directories:
   - $HOME/.gradle/caches

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
-sudo: required
+sudo: false
 language: java
 jdk:
 - oraclejdk8
 services: 
 addons:
   postgresql: '9.5'
+  apt:
+    sources:
+    - precise-pgdg-9.5
+    packages:
+    - postgresql-9.5
 cache:
   directories:
   - $HOME/.gradle/caches
   - $HOME/.gradle/wrapper
 before_script:
-- sudo /etc/init.d/postgresql stop
-- sudo apt-get -y remove --purge postgresql-9.1
-- sudo apt-get -y remove --purge postgresql-9.2
-- sudo apt-get -y remove --purge postgresql-9.3
-- sudo apt-get -y remove --purge postgresql-9.4
-- sudo apt-get -y autoremove
-- sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
-- sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-- sudo apt-get update
-- sudo apt-get -y install postgresql-9.5
-- sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/9.5/main/pg_hba.conf'
-- sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
-- sudo /etc/init.d/postgresql restart
 - psql --version
 - psql -c 'create database test_indexer_mint;' -U postgres
 - psql -c 'create database test_indexer_presentation;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,28 @@
-sudo: false
+sudo: required
 language: java
 jdk:
 - oraclejdk8
 services: 
 addons:
   postgresql: '9.5'
-  apt:
-    sources:
-    - precise-pgdg-9.5
-    packages:
-    - postgresql-9.5
 cache:
   directories:
   - $HOME/.gradle/caches
   - $HOME/.gradle/wrapper
 before_script:
+- sudo /etc/init.d/postgresql stop
+- sudo apt-get -y remove --purge postgresql-9.1
+- sudo apt-get -y remove --purge postgresql-9.2
+- sudo apt-get -y remove --purge postgresql-9.3
+- sudo apt-get -y remove --purge postgresql-9.4
+- sudo apt-get -y autoremove
+- sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
+- sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
+- sudo apt-get update
+- sudo apt-get -y install postgresql-9.5
+- sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/9.5/main/pg_hba.conf'
+- sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
+- sudo /etc/init.d/postgresql restart
 - psql --version
 - psql -c 'create database test_indexer_mint;' -U postgres
 - psql -c 'create database test_indexer_presentation;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: java
 jdk:
 - oraclejdk8
@@ -10,6 +10,20 @@ cache:
   - $HOME/.gradle/caches
   - $HOME/.gradle/wrapper
 before_script:
+- sudo /etc/init.d/postgresql stop
+- sudo apt-get -y remove --purge postgresql-9.1
+- sudo apt-get -y remove --purge postgresql-9.2
+- sudo apt-get -y remove --purge postgresql-9.3
+- sudo apt-get -y remove --purge postgresql-9.4
+- sudo apt-get -y autoremove
+- sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
+- sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
+- sudo apt-get update
+- sudo apt-get -y install postgresql-9.5
+- sudo sh -c 'echo "local all postgres trust" > /etc/postgresql/9.5/main/pg_hba.conf'
+- sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
+- sudo /etc/init.d/postgresql restart
+- psql --version
 - psql -c 'create database test_indexer_mint;' -U postgres
 - psql -c 'create database test_indexer_presentation;' -U postgres
 script:

--- a/src/main/java/uk/gov/indexer/dao/EntryUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/EntryUpdateDAO.java
@@ -4,13 +4,12 @@ import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 
 public interface EntryUpdateDAO extends DBConnectionDAO {
 
     String ENTRY_TABLE = "entry";
 
-    @SqlUpdate("CREATE TABLE IF NOT EXISTS entry (entry_number SERIAL PRIMARY KEY, sha256hex VARCHAR, timestamp TIMESTAMP)")
+    @SqlUpdate("create table if not exists entry (entry_number SERIAL PRIMARY KEY, sha256hex VARCHAR, timestamp timestamp)")
     void ensureEntryTableInPlace();
 
     @SqlQuery("SELECT MAX(entry_number) FROM " + ENTRY_TABLE)

--- a/src/main/java/uk/gov/indexer/dao/Item.java
+++ b/src/main/java/uk/gov/indexer/dao/Item.java
@@ -15,12 +15,9 @@ public class Item {
         this.content = content;
     }
 
+    @SuppressWarnings("unused, used by DAO")
     public String getSha256hex() {
         return sha256hex;
-    }
-
-    public byte[] getContent() {
-        return content;
     }
 
     @SuppressWarnings("unused, used by DAO")

--- a/src/main/java/uk/gov/indexer/dao/ItemUpdateDAO.java
+++ b/src/main/java/uk/gov/indexer/dao/ItemUpdateDAO.java
@@ -2,24 +2,17 @@ package uk.gov.indexer.dao;
 
 import org.skife.jdbi.v2.sqlobject.BindBean;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.unstable.BindIn;
-
-import java.util.List;
 
 @UseStringTemplate3StatementLocator
-public interface ItemUpdateDAO extends DBConnectionDAO {
+interface ItemUpdateDAO extends DBConnectionDAO {
 
     String ITEM_TABLE = "item";
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS item (sha256hex VARCHAR PRIMARY KEY, content JSONB)")
     void ensureItemTableInPlace();
 
-    @SqlBatch("INSERT INTO " + ITEM_TABLE + "(sha256hex, content) VALUES(:sha256hex, :jsonContent)")
+    @SqlBatch("insert into " + ITEM_TABLE + "(sha256hex, content) values(:sha256hex, :jsonContent) on conflict do nothing")
     void writeBatch(@BindBean Iterable<Item> items);
-
-    @SqlQuery("SELECT sha256hex FROM " + ITEM_TABLE + " WHERE sha256hex IN (<item_hex_values>)")
-    List<String> getExistingItemHexValues(@BindIn("item_hex_values") List<String> itemHexValues);
 }

--- a/src/main/java/uk/gov/indexer/dao/Record.java
+++ b/src/main/java/uk/gov/indexer/dao/Record.java
@@ -1,0 +1,11 @@
+package uk.gov.indexer.dao;
+
+public class Record {
+    public final Entry entry;
+    public final Item item;
+
+    public Record(Entry entry, Item item) {
+        this.entry = entry;
+        this.item = item;
+    }
+}


### PR DESCRIPTION
We have upgraded the postgres version to 9.5.2 which got very exciting features, one of them is insert query with conflict http://www.postgresql.org/docs/9.5/static/sql-insert.html.

   Using new insert on conflict query which simplifies code. Also using join query to read item and entries in one object as record.
