### PR TITLE
Travis: Shorter apt-get remove invocation; use right keyserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,9 @@ cache:
   - $HOME/.gradle/wrapper
 before_script:
 - sudo /etc/init.d/postgresql stop
-- sudo apt-get -y remove --purge postgresql-9.1
-- sudo apt-get -y remove --purge postgresql-9.2
-- sudo apt-get -y remove --purge postgresql-9.3
-- sudo apt-get -y remove --purge postgresql-9.4
+- sudo apt-get -y remove --purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4
 - sudo apt-get -y autoremove
-- sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
+- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 7FCC7D46ACCC4CF8
 - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
 - sudo apt-get update
 - sudo apt-get -y install postgresql-9.5


### PR DESCRIPTION
This PR makes the `apt-get` invocation shorter, and uses a valid keyserver for the PostgreSQL debian packages.

Before this change: the output of the keyserver interaction was:

```
$ sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --secret-keyring /tmp/tmp.tnPxKM4gbc --trustdb-name /etc/apt/trustdb.gpg --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d//apt.postgresql.org.gpg --keyserver keys.gnupg.net --recv-keys 7FCC7D46ACCC4CF8
gpg: requesting key ACCC4CF8 from hkp server keys.gnupg.net
gpg: key ACCC4CF8: "PostgreSQL Debian Repository" 1 new signature
gpg: no ultimately trusted keys found
gpg: Total number processed: 1
gpg:         new signatures: 1
```

I made this pull request because your Travis scripts inspired me to start using PG 9.5 in my project. Thank you!
