### PR TITLE
drop default serial value from entry table.

### DIFF
--- a/src/main/resources/sql/init_entry.sql
+++ b/src/main/resources/sql/init_entry.sql
@@ -4,6 +4,8 @@ ensureEntrySchemaInPlace() ::= <<
 
 create table if not exists entry (entry_number serial primary key, sha256hex varchar, timestamp timestamp);
 
+alter table entry alter column entry_number drop default;
+
 create table if not exists total_entries (count integer);
 
 --Insert query below initializes the total_entries table by 0 if it is not initialized yet

--- a/src/main/resources/sql/init_records.sql
+++ b/src/main/resources/sql/init_records.sql
@@ -1,15 +1,12 @@
 group DAO;
 
 ensureRecordTablesInPlace() ::= <<
+
 CREATE TABLE IF NOT EXISTS  current_keys  (KEY VARCHAR PRIMARY KEY, SERIAL_NUMBER INTEGER UNIQUE);
 
 CREATE TABLE IF NOT EXISTS  total_records  (COUNT INTEGER);
 
 --Insert query below initializes the total records for pre existing register by setting the value as no of rows in current_keys table
 INSERT INTO  total_records (COUNT) SELECT (SELECT COUNT(*) FROM  current_keys) WHERE NOT EXISTS(SELECT 1 FROM  total_records );
-
-DROP TRIGGER IF EXISTS total_records_trigger ON  current_keys ;
-
-DROP FUNCTION IF EXISTS total_records_fn();
 
 >>


### PR DESCRIPTION
 Data in presentation `entry` table is copied from mint `entry` table so it should keep the entry_number which is received from mint instead of accidentally using the sequence for it.
